### PR TITLE
Correctly save pwSettings file

### DIFF
--- a/middleware/package.json
+++ b/middleware/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon app.js",
+    "start": "nodemon --ignore 'setup/pwSettings.json' app.js",
     "test": "node --inspect app.js"
   },
   "keywords": [],

--- a/middleware/setup/js/form-process.js
+++ b/middleware/setup/js/form-process.js
@@ -20,8 +20,7 @@ $(function () {
     var formSettings = $('form').serializeArray();
     var submitURL = formSettings[1].value + '/submit-settings';
     
-    formSettings[1].value = formSettings[1].value + '/api';
-    ajaxURL = formSettings[1].value;
+    ajaxURL = formSettings[1].value + '/api';
     //console.log(formSettings);
 
     $.ajax({


### PR DESCRIPTION
When attempting to save the settings file, the javascript would incorrectly append '/api' to the end of the middleware IP address. Once that issue was addressed, nodemon would detect that the saved file has changed, and restart the server preventing the output of the API token and suggested URL.